### PR TITLE
use new cargo's switch to install or update packages when present

### DIFF
--- a/common/configure_fresh_system
+++ b/common/configure_fresh_system
@@ -89,12 +89,8 @@ else
     git pull
 fi
 
-set +e
-cargo uninstall rustfmt
-cargo uninstall racer
-set -e
-cargo install rustfmt
-cargo install racer
+cargo install -f rustfmt
+cargo install -f racer
 
 # go
 export GOPATH="$HOME/go"


### PR DESCRIPTION
Do not uninstall and then install packages, use new `-f` switch instead.
